### PR TITLE
fix url to index page

### DIFF
--- a/README.org
+++ b/README.org
@@ -4,7 +4,7 @@
 
 
 Looking for the workshops index page? Go to
-[[http://tutorials/iq/harvard/edu]].
+[[http://tutorials.iq.harvard.edu]].
 
 Most of the notes for these workshops were written in
 http://orgmode.org markup and should be viewed in the


### PR DESCRIPTION
fixed broken url to the index page for statistical software workshops at IQSS